### PR TITLE
When using match in routes.rb you need to specify a the method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The gem uses a controller to send messages to the server, in some cases you may 
 2. Add a new route in `routes.rb`
 
     ```ruby
-    match 'logger/rails_client_logger/log' => 'logger#log'
+    match 'logger/rails_client_logger/log' => 'logger#log', via: :post
     mount RailsClientLogger::Engine, :at => "logger"
     ```
 


### PR DESCRIPTION
it causes the following error otherwise.

```
ArgumentError (You should not use the `match` method in your router without specifying an HTTP method.
If you want to expose your action to both GET and POST, add `via: [:get, :post]` option.
If you want to expose your action to GET, use `get` in the router:
  Instead of: match "controller#action"
  Do: get "controller#action"):
  config/routes.rb:132:in `block in <top (required)>'
  config/routes.rb:3:in `<top (required)>'
```
